### PR TITLE
refactor: 포장지 선택 페이지 리팩토링

### DIFF
--- a/WHOA_iOS.xcodeproj/project.pbxproj
+++ b/WHOA_iOS.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		548C4AE72B8E694A002F4FCB /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548C4AE62B8E694A002F4FCB /* Constants.swift */; };
 		548C4AEA2B8E6B75002F4FCB /* KeywordHScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548C4AE92B8E6B75002F4FCB /* KeywordHScrollView.swift */; };
 		548C4AED2B8E98F6002F4FCB /* FlowerListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548C4AEC2B8E98F6002F4FCB /* FlowerListCell.swift */; };
+		54A73F502CE4B6B70027E63E /* PackagingSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A73F4F2CE4B6B70027E63E /* PackagingSelectionView.swift */; };
+		54A73F522CE4EB180027E63E /* RequirementTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A73F512CE4EB180027E63E /* RequirementTextView.swift */; };
 		54BF6D7D2C4057A900928B3F /* SizeAdjustments+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF6D7C2C4057A900928B3F /* SizeAdjustments+.swift */; };
 		54BF6D7F2C440C4800928B3F /* ImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF6D7E2C440C4800928B3F /* ImageProvider.swift */; };
 		54C789D72C207FE00068B6F8 /* KeywordType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C789D62C207FE00068B6F8 /* KeywordType.swift */; };
@@ -348,6 +350,8 @@
 		548C4AE62B8E694A002F4FCB /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		548C4AE92B8E6B75002F4FCB /* KeywordHScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordHScrollView.swift; sourceTree = "<group>"; };
 		548C4AEC2B8E98F6002F4FCB /* FlowerListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerListCell.swift; sourceTree = "<group>"; };
+		54A73F4F2CE4B6B70027E63E /* PackagingSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackagingSelectionView.swift; sourceTree = "<group>"; };
+		54A73F512CE4EB180027E63E /* RequirementTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementTextView.swift; sourceTree = "<group>"; };
 		54BF6D7C2C4057A900928B3F /* SizeAdjustments+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SizeAdjustments+.swift"; sourceTree = "<group>"; };
 		54BF6D7E2C440C4800928B3F /* ImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProvider.swift; sourceTree = "<group>"; };
 		54C789D62C207FE00068B6F8 /* KeywordType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordType.swift; sourceTree = "<group>"; };
@@ -803,9 +807,19 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		54A73F4E2CE4B6A80027E63E /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				54A73F4F2CE4B6B70027E63E /* PackagingSelectionView.swift */,
+				54A73F512CE4EB180027E63E /* RequirementTextView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		54D6B7E22B9CA9D900628FF7 /* PackagingSelection */ = {
 			isa = PBXGroup;
 			children = (
+				54A73F4E2CE4B6A80027E63E /* Views */,
 				54D6B7E32B9CAA7200628FF7 /* PackagingSelectionViewController.swift */,
 				54D6B7E52B9CAEA200628FF7 /* PackagingSelectionViewModel.swift */,
 				5411BA3B2BE27795002A85F0 /* PackagingSelectionModel.swift */,
@@ -1402,6 +1416,7 @@
 				5415DB7B2CC1229D00FD70D6 /* FlowerImageView.swift in Sources */,
 				080D501D2C887F3C0080CD85 /* PatchBouquetStatusAPI.swift in Sources */,
 				0886DA652B957C87003779CE /* RequestDetailViewModel.swift in Sources */,
+				54A73F502CE4B6B70027E63E /* PackagingSelectionView.swift in Sources */,
 				54EA0E702BF6183B007B8F5A /* ShadowBorderLine.swift in Sources */,
 				086E3D6E2C41792000C90787 /* NoRequestCell.swift in Sources */,
 				54EB17E62BA354F400717E6F /* PhotoCell.swift in Sources */,
@@ -1456,6 +1471,7 @@
 				0843605B2C08FA8700B18B90 /* TodaysFlowerAPI.swift in Sources */,
 				0843605C2C08FA9C00B18B90 /* FlowerSearchViewModel.swift in Sources */,
 				08D0CF332BF70D5B005CBECA /* ToolTipView.swift in Sources */,
+				54A73F522CE4EB180027E63E /* RequirementTextView.swift in Sources */,
 				0800412E2C302D5F00CDA693 /* CustomTableView.swift in Sources */,
 				54EB17CC2B9D83E200717E6F /* RangeSlider.swift in Sources */,
 				54EB17D12BA08C2100717E6F /* PhotoSelectionViewController.swift in Sources */,

--- a/WHOA_iOS/Global/Extensions/UITextView+.swift
+++ b/WHOA_iOS/Global/Extensions/UITextView+.swift
@@ -14,4 +14,16 @@ extension UITextView {
             .compactMap{ ($0.object as? UITextView)?.text ?? "" }
             .eraseToAnyPublisher()
     }
+    
+    var textDidBeginEditingPublisher: AnyPublisher<Void, Never> {
+        NotificationCenter.default.publisher(for: UITextView.textDidBeginEditingNotification, object: self)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+    
+    var textDidEndEditingPublisher: AnyPublisher<Void, Never> {
+        NotificationCenter.default.publisher(for: UITextView.textDidEndEditingNotification, object: self)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
 }

--- a/WHOA_iOS/Global/Extensions/UITextView+.swift
+++ b/WHOA_iOS/Global/Extensions/UITextView+.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 
 extension UITextView {
-    var publisher: AnyPublisher<String, Never> {
+    var textDidChangePublisher: AnyPublisher<String, Never> {
         NotificationCenter.default.publisher(for: UITextView.textDidChangeNotification, object: self)
             .compactMap{ ($0.object as? UITextView)?.text ?? "" }
             .eraseToAnyPublisher()

--- a/WHOA_iOS/UI/FlowerCustomizing/Alternatives/Views/AlternativesView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/Alternatives/Views/AlternativesView.swift
@@ -82,7 +82,6 @@ final class AlternativesView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
-        observe()
     }
     
     required init?(coder: NSCoder) {
@@ -102,20 +101,13 @@ final class AlternativesView: UIView {
         setupAutoLayout()
     }
     
-    private func observe() {
-        alternativeSubject
-            .sink { [weak self] alternative in
-                self?.nextButton.isActive = (alternative != .none)
-            }
-            .store(in: &cancellables)
-    }
-    
     func updateButtonSelection(for alternative: AlternativesType) {
         let isColorSelected = (alternative == .colorOriented)
         let isHashTagSelected = (alternative == .hashTagOriented)
         
         colorOrientedButton.updateSelectionState(isSelected: isColorSelected)
         hashTagOrientedButton.updateSelectionState(isSelected: isHashTagSelected)
+        nextButton.isActive = (alternative != .none)
     }
 }
 

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
@@ -6,80 +6,41 @@
 //
 
 import UIKit
+import Combine
 
 final class PackagingSelectionViewController: UIViewController {
     
-    // MARK: - Initialize
+    // MARK: - Enums
+    
+    /// Metrics
+    private enum Metric {
+        static let sideMargin = 20.0
+        static let packagingSelectionViewTopOffset = 32.0
+        static let requirementTextViewTopOffset = 16.0
+        static let requirementTextViewHeightMultiplier = 0.34
+    }
+    
+    /// Attributes
+    private enum Attributes {
+        static let headerViewTitle = "원하는 포장지 종류가 있나요?"
+    }
+    
+    // MARK: - Properties
     
     let viewModel: PackagingSelectionViewModel
     weak var coordinator: CustomizingCoordinator?
     
     // MARK: - UI
     
-    private lazy var exitButton = ExitButton(currentVC: self, coordinator: coordinator)
-    private let progressHStackView = CustomProgressHStackView(numerator: 4, denominator: 7)
-    private let titleLabel = CustomTitleLabel(text: "원하는 포장지 종류가 있나요?")
-    
-    private let managerAssignButton: SpacebarButton = {
-        let button = SpacebarButton(title: "아니요, \(PackagingAssignType.managerAssign.rawValue)")
-        button.addTarget(self, action: #selector(assignButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private let myselfAssignButton: SpacebarButton = {
-        let button = SpacebarButton(title: "네, \(PackagingAssignType.myselfAssign.rawValue)")
-        button.addTarget(self, action: #selector(assignButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var requirementTextView: UITextView = {
-        let view = UITextView()
-        view.font = .Pretendard()
-        view.textColor = .black
-        view.backgroundColor = .white
-        view.layer.cornerRadius = 10
-        view.layer.masksToBounds = true
-        view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.gray04.cgColor
-        view.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        view.isHidden = true
-        view.delegate = self
-        return view
-    }()
-    
-    private let placeholder: UILabel = {
-        let label = UILabel()
-        label.text = "요구사항을 작성해주세요."
-        label.textColor = .gray06
-        label.font = .Pretendard()
-        return label
-    }()
-    
-    private let borderLine = ShadowBorderLine()
-    
-    private let backButton: BackButton = {
-        let button = BackButton(isActive: true)
-        button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private let nextButton: NextButton = {
-        let button = NextButton()
-        button.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var navigationHStackView: UIStackView = {
-        let stackView = UIStackView()
-        [
-            backButton,
-            nextButton
-        ].forEach { stackView.addArrangedSubview($0)}
-        stackView.axis = .horizontal
-        stackView.distribution = .fillProportionally
-        stackView.spacing = 9
-        return stackView
-    }()
+    private lazy var headerView = CustomHeaderView(
+        currentVC: self,
+        coordinator: coordinator,
+        numerator: 4,
+        title: Attributes.headerViewTitle
+    )
+    private let packagingSelectionView = PackagingSelectionView()
+    private let requirementTextView = RequirementTextView()
+    private let bottomView = CustomBottomView(backButtonState: .enabled, nextButtonEnabled: false)
     
     // MARK: - Initialize
     
@@ -96,23 +57,18 @@ final class PackagingSelectionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        bind()
         setupUI()
+        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        extendedLayoutIncludesOpaqueBars = true
-        navigationController?.setNavigationBarHidden(true, animated: false)
-        tabBarController?.tabBar.isHidden = true
+        configNavigationBar(isHidden: true)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        extendedLayoutIncludesOpaqueBars = false
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        tabBarController?.tabBar.isHidden = false
+        configNavigationBar(isHidden: false)
     }
     
     // MARK: - Functions
@@ -120,19 +76,12 @@ final class PackagingSelectionViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .white
         
-        view.addSubview(exitButton)
-        view.addSubview(progressHStackView)
-        view.addSubview(titleLabel)
-        
-        view.addSubview(managerAssignButton)
-        view.addSubview(myselfAssignButton)
-        
-        view.addSubview(requirementTextView)
-        requirementTextView.addSubview(placeholder)
-        
-        view.addSubview(borderLine)
-        view.addSubview(navigationHStackView)
-        
+        [
+            headerView,
+            packagingSelectionView,
+            requirementTextView,
+            bottomView
+        ].forEach(view.addSubview(_:))
         setupAutoLayout()
     }
     
@@ -140,134 +89,97 @@ final class PackagingSelectionViewController: UIViewController {
         viewModel.$packagingSelectionModel
             .receive(on: RunLoop.main)
             .sink { [weak self] model in
-                self?.updateUI(with: model)
+//                self?.updateUI(with: model)
             }
-            .store(in: &viewModel.cancellables)
-        
-        viewModel.$isNextButtonActive
-            .receive(on: RunLoop.main)
-            .assign(to: \.isActive, on: nextButton)
             .store(in: &viewModel.cancellables)
     }
     
-    private func updateUI(with model: PackagingSelectionModel) {
-        managerAssignButton.isSelected = model.packagingAssignButtonType == .managerAssign
-        myselfAssignButton.isSelected = model.packagingAssignButtonType == .myselfAssign
-        requirementTextView.isHidden = model.packagingAssignButtonType != .myselfAssign
-        
-        managerAssignButton.configuration = managerAssignButton.configure(isSelected: managerAssignButton.isSelected)
-        myselfAssignButton.configuration = myselfAssignButton.configure(isSelected: myselfAssignButton.isSelected)
-        
-        if model.packagingAssignButtonType == .myselfAssign {
-            requirementTextView.text = model.text
-            placeholder.isHidden = !model.text.isEmpty
-        }
-    }
+//    private func updateUI(with model: PackagingSelectionModel) {
+//        managerAssignButton.isSelected = model.packagingAssignButtonType == .managerAssign
+//        myselfAssignButton.isSelected = model.packagingAssignButtonType == .myselfAssign
+//        requirementTextView.isHidden = model.packagingAssignButtonType != .myselfAssign
+//        
+//        managerAssignButton.configuration = managerAssignButton.configure(isSelected: managerAssignButton.isSelected)
+//        myselfAssignButton.configuration = myselfAssignButton.configure(isSelected: myselfAssignButton.isSelected)
+//        
+//        if model.packagingAssignButtonType == .myselfAssign {
+//            requirementTextView.text = model.text
+//            placeholder.isHidden = !model.text.isEmpty
+//        }
+//    }
     
     // MARK: - Actions
     
-    @objc
-    private func assignButtonTapped(_ sender: UIButton) {
-        let assignType: PackagingAssignType = sender === managerAssignButton ?
-            .managerAssign : .myselfAssign
-        
-        viewModel.getPackagingAssign(packagingAssign: assignType)
-    }
+//    @objc
+//    private func assignButtonTapped(_ sender: UIButton) {
+//        let assignType: PackagingAssignType = sender === managerAssignButton ?
+//            .managerAssign : .myselfAssign
+//        
+//        viewModel.getPackagingAssign(packagingAssign: assignType)
+//    }
+//    
+//    @objc
+//    func backButtonTapped() {
+//        navigationController?.popViewController(animated: true)
+//    }
+//    
     
-    @objc
-    func backButtonTapped() {
-        navigationController?.popViewController(animated: true)
-    }
-    
-    @objc
-    func nextButtonTapped() {
-        let model = viewModel.packagingSelectionModel
-        let text = model.packagingAssignButtonType == .myselfAssign ? model.text : nil
-        let assign = BouquetData.PackagingAssign(assign: model.packagingAssignButtonType ?? .none, text: text)
-        viewModel.dataManager.setPackagingAssign(assign)
-        coordinator?.showFlowerPriceVC()
-    }
+//    func nextButtonTapped() {
+//        let model = viewModel.packagingSelectionModel
+//        let text = model.packagingAssignButtonType == .myselfAssign ? model.text : nil
+//        let assign = BouquetData.PackagingAssign(assign: model.packagingAssignButtonType ?? .none, text: text)
+//        viewModel.dataManager.setPackagingAssign(assign)
+//        coordinator?.showFlowerPriceVC()
+//    }
 }
+
+// MARK: - AutoLayout
 
 extension PackagingSelectionViewController {
     private func setupAutoLayout() {
-        exitButton.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(17)
-            $0.leading.equalToSuperview().offset(22)
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview().inset(Metric.sideMargin)
         }
         
-        progressHStackView.snp.makeConstraints {
-            $0.top.equalTo(exitButton.snp.bottom).offset(29)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(19.5)
-            $0.height.equalTo(12.75)
-        }
-        
-        titleLabel.snp.makeConstraints {
-            $0.top.equalTo(progressHStackView.snp.bottom).offset(32)
-            $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview().inset(91)
-        }
-        
-        managerAssignButton.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(32)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(56)
-        }
-        
-        myselfAssignButton.snp.makeConstraints {
-            $0.top.equalTo(managerAssignButton.snp.bottom).offset(12)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(56)
+        packagingSelectionView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(Metric.packagingSelectionViewTopOffset)
+            $0.leading.trailing.equalToSuperview().inset(Metric.sideMargin)
         }
         
         requirementTextView.snp.makeConstraints {
-            $0.top.equalTo(myselfAssignButton.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(120)
+            $0.top.equalTo(packagingSelectionView.snp.bottom).offset(Metric.requirementTextViewTopOffset)
+            $0.leading.trailing.equalToSuperview().inset(Metric.sideMargin)
+            $0.height.equalTo(self.requirementTextView.snp.width).multipliedBy(Metric.requirementTextViewHeightMultiplier)
         }
         
-        placeholder.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().offset(20)
-        }
-        
-        borderLine.snp.makeConstraints {
-            $0.top.equalTo(navigationHStackView.snp.top).offset(-20)
+        bottomView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2)
-        }
-        
-        backButton.snp.makeConstraints {
-            $0.width.equalTo(110)
-            $0.height.equalTo(56)
-        }
-        
-        navigationHStackView.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-8)
-            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
 }
 
-extension PackagingSelectionViewController: UITextViewDelegate {
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        requirementTextView.layer.borderColor = UIColor.second1.cgColor
-        
-        placeholder.isHidden = true
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        requirementTextView.layer.borderColor = UIColor.gray04.cgColor
-        
-        if textView.text.count == 0 {
-            placeholder.isHidden = false
-        }
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true) /// 화면을 누르면 키보드 내려가게 하는 것
-    }
-    
-    func textViewDidChange(_ textView: UITextView) {
-        viewModel.updateText(textView.text)
-    }
-}
+//extension PackagingSelectionViewController: UITextViewDelegate {
+//    func textViewDidBeginEditing(_ textView: UITextView) {
+//        requirementTextView.layer.borderColor = UIColor.second1.cgColor
+//        
+//        placeholder.isHidden = true
+//    }
+//    
+//    func textViewDidEndEditing(_ textView: UITextView) {
+//        requirementTextView.layer.borderColor = UIColor.gray04.cgColor
+//        
+//        if textView.text.count == 0 {
+//            placeholder.isHidden = false
+//        }
+//    }
+//    
+//    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+//        self.view.endEditing(true) /// 화면을 누르면 키보드 내려가게 하는 것
+//    }
+//    
+//    func textViewDidChange(_ textView: UITextView) {
+//        viewModel.updateText(textView.text)
+//    }
+//}

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
@@ -31,6 +31,15 @@ final class PackagingSelectionViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     weak var coordinator: CustomizingCoordinator?
     
+    private lazy var viewTapPublisher: AnyPublisher<Void, Never> = {
+        let tapGesture = UITapGestureRecognizer()
+        view.addGestureRecognizer(tapGesture)
+        return tapGesture.publisher(for: \.state)
+            .filter { $0 == .ended }
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }()
+    
     // MARK: - UI
     
     private lazy var headerView = CustomHeaderView(
@@ -60,6 +69,7 @@ final class PackagingSelectionViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         bind()
+        observe()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -109,6 +119,14 @@ final class PackagingSelectionViewController: UIViewController {
             }
             .store(in: &cancellables)
     }
+    
+    private func observe() {
+        viewTapPublisher
+            .sink { [weak self] _ in
+                self?.view.endEditing(true)
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - AutoLayout
@@ -137,27 +155,3 @@ extension PackagingSelectionViewController {
         }
     }
 }
-
-//extension PackagingSelectionViewController: UITextViewDelegate {
-//    func textViewDidBeginEditing(_ textView: UITextView) {
-//        requirementTextView.layer.borderColor = UIColor.second1.cgColor
-//        
-//        placeholder.isHidden = true
-//    }
-//    
-//    func textViewDidEndEditing(_ textView: UITextView) {
-//        requirementTextView.layer.borderColor = UIColor.gray04.cgColor
-//        
-//        if textView.text.count == 0 {
-//            placeholder.isHidden = false
-//        }
-//    }
-//    
-//    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-//        self.view.endEditing(true) /// 화면을 누르면 키보드 내려가게 하는 것
-//    }
-//    
-//    func textViewDidChange(_ textView: UITextView) {
-//        viewModel.updateText(textView.text)
-//    }
-//}

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
@@ -119,7 +119,7 @@ final class PackagingSelectionViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-        input.nextButtonTapped
+        output.showFlowerPriceView
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.coordinator?.showFlowerPriceVC()
@@ -131,6 +131,12 @@ final class PackagingSelectionViewController: UIViewController {
         viewTapPublisher
             .sink { [weak self] _ in
                 self?.view.endEditing(true)
+            }
+            .store(in: &cancellables)
+        
+        bottomView.backButtonTappedPublisher
+            .sink { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellables)
     }

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewController.swift
@@ -112,6 +112,13 @@ final class PackagingSelectionViewController: UIViewController {
             }
             .store(in: &cancellables)
         
+        output.nextButtonEnabled
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEnabled in
+                self?.bottomView.configNextButton(isEnabled)
+            }
+            .store(in: &cancellables)
+        
         input.nextButtonTapped
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewModel.swift
@@ -57,6 +57,18 @@ final class PackagingSelectionViewModel: ViewModel {
             }
             .eraseToAnyPublisher()
         
+        input.nextButtonTapped
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                let assign = BouquetData.PackagingAssign(
+                    assign: packagingAssignSubject.value,
+                    text: textInputSubject.value
+                )
+                self.dataManager.setPackagingAssign(assign)
+                self.showFlowerPriceViewSubject.send()
+            }
+            .store(in: &cancellables)
+        
         return Output(
             setupPackagingAssign: packagingAssignSubject.eraseToAnyPublisher(),
             nextButtonEnabled: nextButtonEnabled.eraseToAnyPublisher(),

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/PackagingSelectionViewModel.swift
@@ -8,45 +8,45 @@
 import Foundation
 import Combine
 
-final class PackagingSelectionViewModel {
+final class PackagingSelectionViewModel: ViewModel {
     
     // MARK: - Properties
     
-    let dataManager: BouquetDataManaging
-    @Published var packagingSelectionModel = PackagingSelectionModel(packagingAssignButtonType: nil, text: "")
-    @Published var isNextButtonActive = false
-    var cancellables = Set<AnyCancellable>()
+    struct Input {
+        let packagingAssignSelected: AnyPublisher<PackagingAssignType, Never>
+        let textInput: AnyPublisher<String, Never>
+        let nextButtonTapped: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let setupPackagingAssign: AnyPublisher<PackagingAssignType, Never>
+        let showFlowerPriceView: AnyPublisher<Void, Never>
+    }
+    
+    private let dataManager: BouquetDataManaging
+    private let packagingAssignSubject: CurrentValueSubject<PackagingAssignType, Never>
+    private let showFlowerPriceViewSubject = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
     
     
     // MARK: - Initialize
     
     init(dataManager: BouquetDataManaging = BouquetDataManager.shared) {
         self.dataManager = dataManager
-        
-        $packagingSelectionModel
-            .map { model -> Bool in
-                guard model.packagingAssignButtonType != .none else { return false }
-                return model.packagingAssignButtonType == .managerAssign ? true : !model.text.isEmpty
-            }
-            .assign(to: \.isNextButtonActive, on: self)
-            .store(in: &cancellables)
-        configData(dataManager.getPackagingAssign())
+        let packagingAssign = dataManager.getPackagingAssign()
+        self.packagingAssignSubject = .init(packagingAssign.assign)
     }
     
     // MARK: - Functions
     
-    private func configData(_ assign: BouquetData.PackagingAssign) {
-        getPackagingAssign(packagingAssign: assign.assign)
-        if let text = assign.text, !text.isEmpty {
-            updateText(text)
-        }
-    }
-    
-    func updateText(_ text: String) {
-        packagingSelectionModel.text = text
-    }
-    
-    func getPackagingAssign(packagingAssign: PackagingAssignType) {
-        packagingSelectionModel.packagingAssignButtonType = packagingAssign
+    func transform(input: Input) -> Output {
+        input.packagingAssignSelected
+            .assign(to: \.value, on: packagingAssignSubject)
+            .store(in: &cancellables)
+        
+        return Output(
+            setupPackagingAssign: packagingAssignSubject.eraseToAnyPublisher(),
+            showFlowerPriceView: showFlowerPriceViewSubject.eraseToAnyPublisher()
+        )
     }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/PackagingSelectionView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/PackagingSelectionView.swift
@@ -1,0 +1,104 @@
+//
+//  PackagingSelectionView.swift
+//  WHOA_iOS
+//
+//  Created by KSH on 11/13/24.
+//
+
+import UIKit
+import Combine
+
+final class PackagingSelectionView: UIView {
+    
+    // MARK: - Enums
+    
+    /// Metrics
+    private enum Metric {
+        static let spacebarButtonHeightMultiplier = 0.16
+        static let myselfAssignButtonTopOffset = 12.0
+        static let placeholderOffset = 20.0
+    }
+    
+    /// Attributes
+    private enum Attributes {
+        static let managerAssignButtonTitle = "아니요, \(PackagingAssignType.managerAssign.rawValue)"
+        static let myselfAssignButtonTitle = "네, \(PackagingAssignType.myselfAssign.rawValue)"
+    }
+    
+    // MARK: - Properties
+    
+    private let packagingAssignSubject = PassthroughSubject<PackagingAssignType, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var valuePublisher: AnyPublisher<PackagingAssignType, Never> {
+        return packagingAssignSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - UI
+    
+    private lazy var managerAssignButton: SpacebarButton = {
+        let button = SpacebarButton(title: Attributes.managerAssignButtonTitle)
+        button.addAction(UIAction { [weak self] _ in
+            guard let self = self else { return }
+            self.packagingAssignSubject.send(.managerAssign)
+        }, for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var myselfAssignButton: SpacebarButton = {
+        let button = SpacebarButton(title: Attributes.myselfAssignButtonTitle)
+        button.addAction(UIAction { [weak self] _ in
+            guard let self = self else { return }
+            self.packagingAssignSubject.send(.myselfAssign)
+        }, for: .touchUpInside)
+        return button
+    }()
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        backgroundColor = .white
+        [
+            managerAssignButton,
+            myselfAssignButton,
+        ].forEach(addSubview(_:))
+        setupAutoLayout()
+    }
+    
+    func updateButtonSelection(for packagingAssign: PackagingAssignType) {
+        let isManagerSelected = (packagingAssign == .managerAssign)
+        let isMyselfSelected = (packagingAssign == .myselfAssign)
+        
+        managerAssignButton.updateSelectionState(isSelected: isManagerSelected)
+        myselfAssignButton.updateSelectionState(isSelected: isMyselfSelected)
+    }
+}
+
+// MARK: - AutoLayout
+
+extension PackagingSelectionView {
+    private func setupAutoLayout() {
+        managerAssignButton.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(self.snp.width).multipliedBy(Metric.spacebarButtonHeightMultiplier)
+        }
+        
+        myselfAssignButton.snp.makeConstraints {
+            $0.top.equalTo(managerAssignButton.snp.bottom).offset(Metric.myselfAssignButtonTopOffset)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(managerAssignButton.snp.height)
+        }
+    }
+}
+

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -61,7 +61,6 @@ final class RequirementTextView: UIView {
         super.init(frame: frame)
         setupUI()
         bind()
-        observe()
     }
     
     required init?(coder: NSCoder) {
@@ -82,13 +81,21 @@ final class RequirementTextView: UIView {
                 self?.textInputSubject.send(text)
             }
             .store(in: &cancellables)
-    }
-
-    private func observe() {
-        textInputSubject
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] text in
-                self?.placeholder.isHidden = !text.isEmpty
+        
+        textView.textDidBeginEditingPublisher
+            .sink { [weak self] _ in
+                self?.textView.layer.borderColor = UIColor.second1.cgColor
+                self?.placeholder.isHidden = true
+            }
+            .store(in: &cancellables)
+        
+        textView.textDidEndEditingPublisher
+            .sink { [weak self] _ in
+                self?.textView.layer.borderColor = UIColor.gray04.cgColor
+                
+                if self?.textView.text.isEmpty ?? true {
+                    self?.placeholder.isHidden = false
+                }
             }
             .store(in: &cancellables)
     }

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -70,6 +70,7 @@ final class RequirementTextView: UIView {
     // MARK: - Functions
     
     private func setupUI() {
+        backgroundColor = .white
         addSubview(textView)
         textView.addSubview(placeholder)
         setupAutoLayout()

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -1,0 +1,82 @@
+//
+//  RequirementTextView.swift
+//  WHOA_iOS
+//
+//  Created by KSH on 11/13/24.
+//
+
+import UIKit
+import Combine
+
+final class RequirementTextView: UIView {
+    
+    // MARK: - Enums
+    
+    /// Metrics
+    private enum Metric {
+        static let placeholderOffset = 20.0
+    }
+    
+    /// Attributes
+    private enum Attributes {
+        static let placeholder = "요구사항을 작성해주세요."
+    }
+    
+    // MARK: - Properties
+    
+    private let textView: UITextView = {
+        let view = UITextView()
+        view.font = .Pretendard()
+        view.textColor = .black
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.gray04.cgColor
+        view.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
+//        view.isHidden = true
+        //        view.delegate = self
+        return view
+    }()
+    
+    private let placeholder: UILabel = {
+        let label = UILabel()
+        label.text = Attributes.placeholder
+        label.textColor = .gray06
+        label.font = .Pretendard()
+        return label
+    }()
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        addSubview(textView)
+        textView.addSubview(placeholder)
+        setupAutoLayout()
+    }
+}
+
+// MARK: - AutoLayout
+
+extension RequirementTextView {
+    private func setupAutoLayout() {
+        textView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        placeholder.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().offset(Metric.placeholderOffset)
+        }
+    }
+}

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -24,6 +24,15 @@ final class RequirementTextView: UIView {
     
     // MARK: - Properties
     
+    private let textInputSubject = CurrentValueSubject<String, Never>("")
+    private var cancellables = Set<AnyCancellable>()
+    
+    var textInputPublisher: AnyPublisher<String, Never> {
+        textInputSubject.eraseToAnyPublisher()
+    }
+    
+    // MARK: - UI
+    
     private let textView: UITextView = {
         let view = UITextView()
         view.font = .Pretendard()
@@ -34,8 +43,7 @@ final class RequirementTextView: UIView {
         view.layer.borderWidth = 1
         view.layer.borderColor = UIColor.gray04.cgColor
         view.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-//        view.isHidden = true
-        //        view.delegate = self
+        view.isHidden = true
         return view
     }()
     
@@ -52,6 +60,8 @@ final class RequirementTextView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        bind()
+        observe()
     }
     
     required init?(coder: NSCoder) {
@@ -64,6 +74,27 @@ final class RequirementTextView: UIView {
         addSubview(textView)
         textView.addSubview(placeholder)
         setupAutoLayout()
+    }
+    
+    private func bind() {
+        textView.publisher
+            .sink { [weak self] text in
+                self?.textInputSubject.send(text)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func observe() {
+        textInputSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] text in
+                self?.placeholder.isHidden = !text.isEmpty
+            }
+            .store(in: &cancellables)
+    }
+    
+    func setTextViewHidden(_ isHidden: Bool) {
+        textView.isHidden = isHidden
     }
 }
 

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -77,7 +77,7 @@ final class RequirementTextView: UIView {
     }
     
     private func bind() {
-        textView.publisher
+        textView.textDidChangePublisher
             .sink { [weak self] text in
                 self?.textInputSubject.send(text)
             }


### PR DESCRIPTION
## Task
1. ViewModel Input/Output 패턴 적용: 데이터 흐름 명확화를 하고 코드의 일관성을 유지하기 위해 ViewModel에 Input/Output 패턴을 적용했습니다.
2. Metric 및 Attributes Enum 도입: UI 요소에 관련된 상수들을 Metric 및 Attributes라는 Enum으로 분리하여 상수 값들을 한 곳에서 관리하고 유지보수성을 높였습니다.

 ## Issue 번호
* resolved: #72 

# 변경 사항 및 이유

> [구매목적 뷰 리팩토링](https://gist.github.com/Hun-322/bd438a325a86629ee77637d0947464c5)을 참고해주시면 됩니다.