### PR TITLE
refactor: 꽃다발 가격 설정 페이지 리팩토링

### DIFF
--- a/WHOA_iOS.xcodeproj/project.pbxproj
+++ b/WHOA_iOS.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		54EB18102BBF4C2C00717E6F /* FlowerKeywordDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EB180F2BBF4C2C00717E6F /* FlowerKeywordDTO.swift */; };
 		54EB18122BBF542C00717E6F /* FlowerKeywordModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EB18112BBF542C00717E6F /* FlowerKeywordModel.swift */; };
 		54EB18152BC018C900717E6F /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EB18142BC018C900717E6F /* UIImageView+.swift */; };
+		54EFB5232CE989E9007C01B0 /* ThumbButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EFB5222CE989E9007C01B0 /* ThumbButton.swift */; };
 		54F695942BF15007009E3E4D /* MemberRegisterDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F695932BF15007009E3E4D /* MemberRegisterDTO.swift */; };
 		54F695962BF1505D009E3E4D /* MemberRegisterAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F695952BF1505D009E3E4D /* MemberRegisterAPI.swift */; };
 		54F695982BF1B823009E3E4D /* MemberRegisterRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F695972BF1B823009E3E4D /* MemberRegisterRequestDTO.swift */; };
@@ -394,6 +395,7 @@
 		54EB180F2BBF4C2C00717E6F /* FlowerKeywordDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerKeywordDTO.swift; sourceTree = "<group>"; };
 		54EB18112BBF542C00717E6F /* FlowerKeywordModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerKeywordModel.swift; sourceTree = "<group>"; };
 		54EB18142BC018C900717E6F /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		54EFB5222CE989E9007C01B0 /* ThumbButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbButton.swift; sourceTree = "<group>"; };
 		54F695932BF15007009E3E4D /* MemberRegisterDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRegisterDTO.swift; sourceTree = "<group>"; };
 		54F695952BF1505D009E3E4D /* MemberRegisterAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRegisterAPI.swift; sourceTree = "<group>"; };
 		54F695972BF1B823009E3E4D /* MemberRegisterRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRegisterRequestDTO.swift; sourceTree = "<group>"; };
@@ -865,6 +867,7 @@
 			isa = PBXGroup;
 			children = (
 				54EB17CB2B9D83E200717E6F /* RangeSlider.swift */,
+				54EFB5222CE989E9007C01B0 /* ThumbButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1417,6 +1420,7 @@
 				080D501D2C887F3C0080CD85 /* PatchBouquetStatusAPI.swift in Sources */,
 				0886DA652B957C87003779CE /* RequestDetailViewModel.swift in Sources */,
 				54A73F502CE4B6B70027E63E /* PackagingSelectionView.swift in Sources */,
+				54EFB5232CE989E9007C01B0 /* ThumbButton.swift in Sources */,
 				54EA0E702BF6183B007B8F5A /* ShadowBorderLine.swift in Sources */,
 				086E3D6E2C41792000C90787 /* NoRequestCell.swift in Sources */,
 				54EB17E62BA354F400717E6F /* PhotoCell.swift in Sources */,
@@ -1649,7 +1653,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 55D3CXADSB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WHOA_iOS/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "요구서를 앨범에 저장하려면 갤러리 접근 권한이 필요합니다.";
@@ -1686,7 +1690,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 55D3CXADSB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WHOA_iOS/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "요구서를 앨범에 저장하려면 갤러리 접근 권한이 필요합니다.";

--- a/WHOA_iOS.xcodeproj/project.pbxproj
+++ b/WHOA_iOS.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		54FD0F7F2B742C4900F964C3 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FD0F7E2B742C4900F964C3 /* BackButton.swift */; };
 		54FD0F812B743C0000F964C3 /* NextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FD0F802B743C0000F964C3 /* NextButton.swift */; };
 		54FD0F852B74C13B00F964C3 /* PurposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FD0F842B74C13B00F964C3 /* PurposeType.swift */; };
+		54FD47CA2CEDE9FD008EBC16 /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FD47C92CEDE9FD008EBC16 /* Double+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -420,6 +421,7 @@
 		54FD0F7E2B742C4900F964C3 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		54FD0F802B743C0000F964C3 /* NextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextButton.swift; sourceTree = "<group>"; };
 		54FD0F842B74C13B00F964C3 /* PurposeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurposeType.swift; sourceTree = "<group>"; };
+		54FD47C92CEDE9FD008EBC16 /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -952,6 +954,7 @@
 				08B9815A2C30877000F3CD45 /* UILabel+.swift */,
 				080199762C34731E00EB01CF /* UIStackView+.swift */,
 				54BF6D7C2C4057A900928B3F /* SizeAdjustments+.swift */,
+				54FD47C92CEDE9FD008EBC16 /* Double+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1425,6 +1428,7 @@
 				086E3D6E2C41792000C90787 /* NoRequestCell.swift in Sources */,
 				54EB17E62BA354F400717E6F /* PhotoCell.swift in Sources */,
 				54FD0F852B74C13B00F964C3 /* PurposeType.swift in Sources */,
+				54FD47CA2CEDE9FD008EBC16 /* Double+.swift in Sources */,
 				54EB17ED2BAB103900717E6F /* CustomizingSummaryViewController.swift in Sources */,
 				54EB17E32BA2F07D00717E6F /* PhotoViewController.swift in Sources */,
 				54EB17EA2BA9ED5700717E6F /* UIButton+.swift in Sources */,

--- a/WHOA_iOS/Global/Extensions/Double+.swift
+++ b/WHOA_iOS/Global/Extensions/Double+.swift
@@ -1,0 +1,15 @@
+//
+//  Double+.swift
+//  WHOA_iOS
+//
+//  Created by KSH on 11/20/24.
+//
+
+import Foundation
+
+extension Double {
+    /// 천 단위 반올림한 정수 반환 함수입니다.
+    func roundedToThousands() -> Int {
+        return Int((self / 1000.0).rounded() * 1000)
+    }
+}

--- a/WHOA_iOS/UI/FlowerCustomizing/FlowerPrice/FlowerPriceViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/FlowerPrice/FlowerPriceViewModel.swift
@@ -8,12 +8,26 @@
 import Foundation
 import Combine
 
-final class FlowerPriceViewModel {
+final class FlowerPriceViewModel: ViewModel {
     
     // MARK: - Properties
     
+    struct Input {
+        let minPriceChanged: AnyPublisher<Double, Never>
+        let maxPriceChanged: AnyPublisher<Double, Never>
+        let nextButtonTapped: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let initPriceRange: AnyPublisher<(Int, Int), Never>
+        let updatePriceLabel: AnyPublisher<String, Never>
+        let showPhotoSelectionView: AnyPublisher<Void, Never>
+    }
+    
     let dataManager: BouquetDataManaging
-    @Published var flowerPriceModel = FlowerPriceModel(minPrice: 0, maxPrice: 150000)
+    private let minPriceSubject = CurrentValueSubject<Int, Never>(0)
+    private let maxPriceSubject = CurrentValueSubject<Int, Never>(150000)
+    private let showPhotoSelectionViewSubject = PassthroughSubject<Void, Never>()
     var cancellables = Set<AnyCancellable>()
     
     
@@ -22,20 +36,48 @@ final class FlowerPriceViewModel {
     init(dataManager: BouquetDataManaging = BouquetDataManager.shared) {
         self.dataManager = dataManager
         let price = dataManager.getPrice()
-        setPrice(min: Double(price.min), max: Double(price.max))
+        minPriceSubject.send(price.min)
+        maxPriceSubject.send(price.max)
     }
     
     // MARK: - Functions
     
-    func setPrice(min: Double, max: Double) {
-        flowerPriceModel = FlowerPriceModel(minPrice: formatNumberToThousands(min), maxPrice: formatNumberToThousands(max))
-    }
-    
-    func getPriceString() -> String {
-        return "\(flowerPriceModel.minPrice.decimalFormattedString()) ~ \(flowerPriceModel.maxPrice.decimalFormattedString())원"
-    }
-    
-    private func formatNumberToThousands(_ number: Double) -> Int {
-        return Int(round(number / 1000.0) * 1000)
+    func transform(input: Input) -> Output {
+        let initPriceRange = Just((minPriceSubject.value, maxPriceSubject.value))
+        
+        input.minPriceChanged
+            .map { minPrice in
+                minPrice.roundedToThousands()
+            }.assign(to: \.value, on: minPriceSubject)
+            .store(in: &cancellables)
+        
+        input.maxPriceChanged
+            .map { maxPrice in
+                maxPrice.roundedToThousands()
+            }.assign(to: \.value, on: maxPriceSubject)
+            .store(in: &cancellables)
+        
+        let updatePriceLabel = Publishers.CombineLatest(minPriceSubject, maxPriceSubject)
+            .map { minPrice, maxPrice in
+                "\(minPrice)원 ~ \(maxPrice)원"
+            }
+        
+        input.nextButtonTapped
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                let price = BouquetData.Price(
+                    min: minPriceSubject.value,
+                    max: maxPriceSubject.value
+                )
+                self.dataManager.setPrice(price)
+                self.showPhotoSelectionViewSubject.send()
+            }
+            .store(in: &cancellables)
+        
+        return Output(
+            initPriceRange: initPriceRange.eraseToAnyPublisher(),
+            updatePriceLabel: updatePriceLabel.eraseToAnyPublisher(),
+            showPhotoSelectionView: showPhotoSelectionViewSubject.eraseToAnyPublisher()
+        )
     }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/FlowerPrice/Views/ThumbButton.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/FlowerPrice/Views/ThumbButton.swift
@@ -1,0 +1,37 @@
+//
+//  ThumbButton.swift
+//  WHOA_iOS
+//
+//  Created by KSH on 11/17/24.
+//
+
+import UIKit
+
+final class ThumbButton: UIButton {
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Lifecycle
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.frame.height / 2
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        self.backgroundColor = .white
+        self.layer.borderWidth = 2
+        self.layer.borderColor = UIColor.secondary03.cgColor
+    }
+}

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -368,7 +368,6 @@ final class PhotoSelectionViewController: UIViewController {
     @objc
     private func nextButtonTapped() {
         let model = viewModel.getPhotoSelectionModel()
-        print(model)
         viewModel.dataManager.setRequirement(BouquetData.Requirement(text: model.text, images: model.photoDatas))
         coordinator?.showCustomizingSummaryVC()
     }

--- a/WHOA_iOS/UI/Home/HomeViewController.swift
+++ b/WHOA_iOS/UI/Home/HomeViewController.swift
@@ -232,16 +232,12 @@ final class HomeViewController: UIViewController {
     }
     
     private func resetTimer() {
-        print("== 타이머 세팅 ==")
         timer?.invalidate()
         timer = nil
         timer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] timer in
-            print("3초 타이머")
             
             let visibleItem = self?.carouselView.indexPathsForVisibleItems[0].item  // 현재 화면에 보이는 아이템의 indexPath
             let nextItem = (visibleItem ?? 0) + 1
-                        
-            print("현재 아이템:\(visibleItem), 다음 아이템: \(nextItem)")
 
             // 다음 indexPath의 item으로 스크롤
             self?.carouselView.scrollToItem(at: [0, nextItem], at: .centeredHorizontally, animated: true)
@@ -357,7 +353,6 @@ extension HomeViewController: UICollectionViewDelegate {
     
     // 직접 스크롤했을 경우 -> 다음 셀이 중앙에 오도록 하는 페이징 효과 위함
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        print("== scrollViewWillEndDragging ==")
         let cellWidthIncludingSpacing: CGFloat = cellSize.width + minimumLineSpacing
 
         let estimatedIndex = scrollView.contentOffset.x / cellWidthIncludingSpacing
@@ -377,7 +372,6 @@ extension HomeViewController: UICollectionViewDelegate {
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        print("== scrollViewDidEndDecelerating ==")
         
         // 새로 적용
         resetTimer()

--- a/WHOA_iOS/UI/MyPage/RequestDetail/RequestDetailViewController.swift
+++ b/WHOA_iOS/UI/MyPage/RequestDetail/RequestDetailViewController.swift
@@ -337,9 +337,7 @@ extension RequestDetailViewController: BouquetProductionSuccessDelegate {
                 let vc = PhotoViewController(photosCount: 0, photoSelectionLimitCount: 1)
                 vc.modalPresentationStyle = .fullScreen
                 vc.completionHandler = { [self] photos in
-                    print("photos: \(photos)")
                     let photoDatas = photos.values.compactMap{ $0 }.compactMap{ $0.pngData() }
-                    print("photoDatas: \(photoDatas[0])")
                     self.viewModel.postProductedBouquetImage(bouquetId: self.viewModel.getBouquetId(),
                                                              imageFile: ImageFile(filename: "RealBouquetImg",
                                                                                   data: photoDatas[0],


### PR DESCRIPTION
## Task
1. ViewModel Input/Output 패턴 적용: 데이터 흐름을 명확화를 하고 코드의 일관성을 유지하기 위해 ViewModel에 Input/Output 패턴을 적용했습니다.
2. Metric 및 Attributes Enum 도입: UI 요소에 관련된 상수들을 Metric 및 Attributes라는 Enum으로 분리하여 상수 값들을 한 곳에서 관리하고 유지보수성을 높였습니다.

 ## Issue 번호
* resolved: #74 

# 변경 사항 및 이유

> [구매목적 뷰 리팩토링](https://gist.github.com/Hun-322/bd438a325a86629ee77637d0947464c5)을 참고해주시면 됩니다.