### PR TITLE
refactor: 요구사항 작성 페이지 리팩토링

### DIFF
--- a/WHOA_iOS.xcodeproj/project.pbxproj
+++ b/WHOA_iOS.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		542DD3E72B7813A300DBFCCC /* PurposeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DD3E62B7813A300DBFCCC /* PurposeViewModel.swift */; };
 		542DD3EB2B78F65D00DBFCCC /* FlowerColorPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DD3EA2B78F65D00DBFCCC /* FlowerColorPickerViewController.swift */; };
 		542DD3EE2B79047C00DBFCCC /* FlowerColorPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DD3ED2B79047C00DBFCCC /* FlowerColorPickerViewModel.swift */; };
+		54453C572CEFF619000E49E3 /* PhotoSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54453C562CEFF619000E49E3 /* PhotoSelectionView.swift */; };
 		544FC0B32C03A5C70091EEE2 /* BouquetDetailDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544FC0B22C03A5C70091EEE2 /* BouquetDetailDTO.swift */; };
 		544FC0B52C03A70D0091EEE2 /* BouquetDetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544FC0B42C03A70D0091EEE2 /* BouquetDetailAPI.swift */; };
 		544FC0B72C03C40C0091EEE2 /* DeleteBouquetDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544FC0B62C03C40C0091EEE2 /* DeleteBouquetDTO.swift */; };
@@ -331,6 +332,7 @@
 		542DD3E62B7813A300DBFCCC /* PurposeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurposeViewModel.swift; sourceTree = "<group>"; };
 		542DD3EA2B78F65D00DBFCCC /* FlowerColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerColorPickerViewController.swift; sourceTree = "<group>"; };
 		542DD3ED2B79047C00DBFCCC /* FlowerColorPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerColorPickerViewModel.swift; sourceTree = "<group>"; };
+		54453C562CEFF619000E49E3 /* PhotoSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSelectionView.swift; sourceTree = "<group>"; };
 		544FC0B22C03A5C70091EEE2 /* BouquetDetailDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BouquetDetailDTO.swift; sourceTree = "<group>"; };
 		544FC0B42C03A70D0091EEE2 /* BouquetDetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BouquetDetailAPI.swift; sourceTree = "<group>"; };
 		544FC0B62C03C40C0091EEE2 /* DeleteBouquetDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteBouquetDTO.swift; sourceTree = "<group>"; };
@@ -902,6 +904,7 @@
 			children = (
 				54EB17E22BA2F07D00717E6F /* PhotoViewController.swift */,
 				54EB17E52BA354F400717E6F /* PhotoCell.swift */,
+				54453C562CEFF619000E49E3 /* PhotoSelectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1316,6 +1319,7 @@
 				08149E9E2BE94CB100F58A34 /* TodaysFlowerDTO.swift in Sources */,
 				08149E9A2BE9103400F58A34 /* HomeModel.swift in Sources */,
 				089D507A2BB951AC00877CE3 /* ColorSheetViewController.swift in Sources */,
+				54453C572CEFF619000E49E3 /* PhotoSelectionView.swift in Sources */,
 				08149E982BE90B1300F58A34 /* CheapFlowerRankingDTO.swift in Sources */,
 				08D245FE2B7FBDA900CDF3B8 /* FlowerSearchViewController.swift in Sources */,
 				54F695962BF1505D009E3E4D /* MemberRegisterAPI.swift in Sources */,
@@ -1657,7 +1661,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 8BXZLWHRYX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WHOA_iOS/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "요구서를 앨범에 저장하려면 갤러리 접근 권한이 필요합니다.";

--- a/WHOA_iOS/Coordinator/AppCoordinator/CustomizingCoordinator.swift
+++ b/WHOA_iOS/Coordinator/AppCoordinator/CustomizingCoordinator.swift
@@ -107,4 +107,23 @@ extension CustomizingCoordinator {
         saveAlertVC.modalPresentationStyle = .overFullScreen
         currentVC.present(saveAlertVC, animated: false)
     }
+    
+    func showPhotoPicker(
+        from currentVC: UIViewController?,
+        photosCount: Int,
+        photoSelectionLimitCount: Int,
+        completion: @escaping ([Int: UIImage?]) -> Void
+    ) {
+        
+        let photoPickerVC = PhotoViewController(
+            photosCount: photosCount,
+            photoSelectionLimitCount: photoSelectionLimitCount
+        )
+        photoPickerVC.modalPresentationStyle = .fullScreen
+        currentVC?.present(photoPickerVC, animated: true)
+        
+        photoPickerVC.completionHandler = { selectedImages in
+            completion(selectedImages)
+        }
+    }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PackagingSelection/Views/RequirementTextView.swift
@@ -43,7 +43,6 @@ final class RequirementTextView: UIView {
         view.layer.borderWidth = 1
         view.layer.borderColor = UIColor.gray04.cgColor
         view.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        view.isHidden = true
         return view
     }()
     

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -124,11 +124,6 @@ final class PhotoSelectionViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-//    private func configUI() {
-//        updateImageViews(with: viewModel.photoSelectionModel.photoDatas)
-//        updateMinusImageViews()
-//    }
-    
 //    private func resetImageViews() {
 //        photoImageView1.image = UIImage(named: "PhotoIcon")
 //        photoImageView2.image = UIImage(named: "PhotoIcon")
@@ -235,11 +230,6 @@ final class PhotoSelectionViewController: UIViewController {
 //            }
 //        }
 //    }
-    
-    @objc
-    private func backButtonTapped() {
-        navigationController?.popViewController(animated: true)
-    }
     
     @objc
     private func nextButtonTapped() {

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -36,6 +36,15 @@ final class PhotoSelectionViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     weak var coordinator: CustomizingCoordinator?
     
+    private lazy var viewTapPublisher: AnyPublisher<Void, Never> = {
+        let tapGesture = UITapGestureRecognizer()
+        view.addGestureRecognizer(tapGesture)
+        return tapGesture.publisher(for: \.state)
+            .filter { $0 == .ended }
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }()
+    
     // MARK: - UI
     
     private lazy var headerView = CustomHeaderView(
@@ -67,7 +76,7 @@ final class PhotoSelectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-//        configUI()
+        observe()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -102,6 +111,12 @@ final class PhotoSelectionViewController: UIViewController {
     }
     
     private func observe() {
+        viewTapPublisher
+            .sink { [weak self] _ in
+                self?.view.endEditing(true)
+            }
+            .store(in: &cancellables)
+        
         bottomView.backButtonTappedPublisher
             .sink { [weak self] _ in
                 self?.navigationController?.popViewController(animated: true)

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -183,32 +183,7 @@ final class PhotoSelectionViewController: UIViewController {
         return scrollView
     }()
     
-    private let borderLine = ShadowBorderLine()
-    
-    private let backButton: UIButton = {
-        let button = BackButton(isActive: true)
-        button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private let nextButton: UIButton = {
-        let button = NextButton()
-        button.isActive = true
-        button.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var navigationHStackView: UIStackView = {
-        let stackView = UIStackView()
-        [
-            backButton,
-            nextButton
-        ].forEach { stackView.addArrangedSubview($0) }
-        stackView.axis = .horizontal
-        stackView.distribution = .fillProportionally
-        stackView.spacing = 9
-        return stackView
-    }()
+    private let bottomView = CustomBottomView(backButtonState: .enabled, nextButtonEnabled: true)
     
     // MARK: - Initialize
     
@@ -245,7 +220,9 @@ final class PhotoSelectionViewController: UIViewController {
         view.backgroundColor = .white
         
         [
-            headerView
+            headerView,
+            bottomView
+            
         ].forEach(view.addSubview(_:))
         
         view.addSubview(requirementLabel)
@@ -258,9 +235,6 @@ final class PhotoSelectionViewController: UIViewController {
         photoImageView1.addSubview(minusImageView1)
         photoImageView2.addSubview(minusImageView2)
         photoImageView3.addSubview(minusImageView3)
-        
-        view.addSubview(borderLine)
-        view.addSubview(navigationHStackView)
         
         setupAutoLayout()
         requirementTextView.delegate = self
@@ -437,20 +411,9 @@ extension PhotoSelectionViewController {
             }
         }
         
-        borderLine.snp.makeConstraints {
-            $0.top.equalTo(navigationHStackView.snp.top).offset(-20)
+        bottomView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2)
-        }
-        
-        backButton.snp.makeConstraints {
-            $0.width.equalTo(110)
-            $0.height.equalTo(56)
-        }
-        
-        navigationHStackView.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-8)
-            $0.leading.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
     }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -15,6 +15,8 @@ final class PhotoSelectionViewController: UIViewController {
     /// Metrics
     private enum Metric {
         static let sideMargin = 20.0
+        static let requirementTextViewTopOffset = 16.0
+        static let requirementTextViewHeightMultiplier = 0.34
     }
     
     /// Attributes
@@ -44,26 +46,7 @@ final class PhotoSelectionViewController: UIViewController {
         return label
     }()
     
-    private let requirementTextView: UITextView = {
-        let view = UITextView()
-        view.font = .Pretendard()
-        view.textColor = .black
-        view.backgroundColor = .white
-        view.layer.cornerRadius = 10
-        view.layer.masksToBounds = true
-        view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.gray06.cgColor
-        view.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        return view
-    }()
-    
-    private let placeholder: UILabel = {
-        let label = UILabel()
-        label.text = "요구사항을 작성해주세요."
-        label.textColor = .gray06
-        label.font = .Pretendard()
-        return label
-    }()
+    private let requirementTextView = RequirementTextView()
     
     private let photoLabel: UILabel = {
         let label = UILabel()
@@ -221,13 +204,12 @@ final class PhotoSelectionViewController: UIViewController {
         
         [
             headerView,
+            requirementLabel,
+            requirementTextView,
             bottomView
             
         ].forEach(view.addSubview(_:))
         
-        view.addSubview(requirementLabel)
-        view.addSubview(requirementTextView)
-        view.addSubview(placeholder)
         view.addSubview(photoLabel)
         view.addSubview(photoImageHScrollView)
         photoImageHScrollView.addSubview(photoImageViewHStackView)
@@ -237,14 +219,11 @@ final class PhotoSelectionViewController: UIViewController {
         photoImageView3.addSubview(minusImageView3)
         
         setupAutoLayout()
-        requirementTextView.delegate = self
     }
     
     private func configUI() {
         updateImageViews(with: viewModel.photoSelectionModel.photoDatas)
         updateMinusImageViews()
-        requirementTextView.text = viewModel.photoSelectionModel.text
-        placeholder.isHidden = viewModel.photoSelectionModel.text != ""
     }
     
     private func resetImageViews() {
@@ -358,6 +337,8 @@ final class PhotoSelectionViewController: UIViewController {
     }
 }
 
+// MARK: - AutoLayout
+
 extension PhotoSelectionViewController {
     private func setupAutoLayout() {
         headerView.snp.makeConstraints {
@@ -368,17 +349,12 @@ extension PhotoSelectionViewController {
         requirementLabel.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom).offset(30)
             $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview().inset(280)
         }
         
         requirementTextView.snp.makeConstraints {
-            $0.top.equalTo(requirementLabel.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(120)
-        }
-        
-        placeholder.snp.makeConstraints {
-            $0.top.leading.equalTo(requirementTextView).offset(20)
+            $0.top.equalTo(requirementLabel.snp.bottom).offset(Metric.requirementTextViewTopOffset)
+            $0.leading.trailing.equalToSuperview().inset(Metric.sideMargin)
+            $0.height.equalTo(self.requirementTextView.snp.width).multipliedBy(Metric.requirementTextViewHeightMultiplier)
         }
         
         photoLabel.snp.makeConstraints {
@@ -415,28 +391,5 @@ extension PhotoSelectionViewController {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
-    }
-}
-
-extension PhotoSelectionViewController: UITextViewDelegate {
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        requirementTextView.layer.borderColor = UIColor.second1.cgColor
-        placeholder.isHidden = true
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        requirementTextView.layer.borderColor = UIColor.gray04.cgColor
-        
-        if textView.text.count == 0 {
-            placeholder.isHidden = false
-        }
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true) /// 화면을 누르면 키보드 내려가게 하는 것
-    }
-    
-    func textViewDidChange(_ textView: UITextView) {
-        viewModel.updateText(textView.text)
     }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 import Photos
 
 final class PhotoSelectionViewController: UIViewController {
@@ -15,8 +16,10 @@ final class PhotoSelectionViewController: UIViewController {
     /// Metrics
     private enum Metric {
         static let sideMargin = 20.0
+        static let requirementLabelTopOffset = 30.0
         static let requirementTextViewTopOffset = 16.0
         static let requirementTextViewHeightMultiplier = 0.34
+        static let photoLabelTopOffset = 40.0
     }
     
     /// Attributes
@@ -43,117 +46,7 @@ final class PhotoSelectionViewController: UIViewController {
     private lazy var requirementLabel = buildLabel(text: Attributes.requirementLabelText)
     private let requirementTextView = RequirementTextView()
     private lazy var photoLabel = buildLabel(text: Attributes.photoLabelText)
-    
-    private lazy var addImageButton: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "plus.circle")
-        imageView.tintColor = .black
-        imageView.contentMode = .center
-        imageView.layer.cornerRadius = 10
-        imageView.layer.masksToBounds = true
-        imageView.backgroundColor = .gray02
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(photoImageViewTapped))
-        imageView.addGestureRecognizer(tapGesture)
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private let photoImageView1: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "PhotoIcon")
-        imageView.contentMode = .center
-        imageView.layer.cornerRadius = 10
-        imageView.layer.masksToBounds = true
-        imageView.backgroundColor = .gray02
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private lazy var minusImageView1: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "MinusButton")
-        imageView.tintColor = .black
-        imageView.contentMode = .scaleAspectFill
-        imageView.isHidden = true
-        imageView.tag = 1
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusImageViewTapped))
-        imageView.addGestureRecognizer(tapGesture)
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private let photoImageView2: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "PhotoIcon")
-        imageView.contentMode = .center
-        imageView.layer.cornerRadius = 10
-        imageView.layer.masksToBounds = true
-        imageView.backgroundColor = .gray02
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private lazy var minusImageView2: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "MinusButton")
-        imageView.tintColor = .black
-        imageView.contentMode = .scaleAspectFill
-        imageView.isHidden = true
-        imageView.tag = 2
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusImageViewTapped))
-        imageView.addGestureRecognizer(tapGesture)
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private let photoImageView3: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "PhotoIcon")
-        imageView.contentMode = .center
-        imageView.layer.cornerRadius = 10
-        imageView.layer.masksToBounds = true
-        imageView.backgroundColor = .gray02
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private lazy var minusImageView3: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(named: "MinusButton")
-        imageView.tintColor = .black
-        imageView.contentMode = .scaleAspectFill
-        imageView.isHidden = true
-        imageView.tag = 3
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusImageViewTapped))
-        imageView.addGestureRecognizer(tapGesture)
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    
-    private lazy var photoImageViewHStackView: UIStackView = {
-        let stackView = UIStackView()
-        [
-            addImageButton,
-            photoImageView1,
-            photoImageView2,
-            photoImageView3
-        ].forEach { stackView.addArrangedSubview($0)}
-        stackView.axis = .horizontal
-        stackView.distribution = .fillEqually
-        stackView.spacing = 12
-        return stackView
-    }()
-    
-    private let photoImageHScrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.showsHorizontalScrollIndicator = false
-        return scrollView
-    }()
-    
+    private let photoSelectionView = PhotoSelectionView()
     private let bottomView = CustomBottomView(backButtonState: .enabled, nextButtonEnabled: true)
     
     // MARK: - Initialize
@@ -172,7 +65,7 @@ final class PhotoSelectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        configUI()
+//        configUI()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -194,57 +87,51 @@ final class PhotoSelectionViewController: UIViewController {
             headerView,
             requirementLabel,
             requirementTextView,
+            photoLabel,
+            photoSelectionView,
             bottomView
             
         ].forEach(view.addSubview(_:))
-        
-        view.addSubview(photoLabel)
-        view.addSubview(photoImageHScrollView)
-        photoImageHScrollView.addSubview(photoImageViewHStackView)
-        
-        photoImageView1.addSubview(minusImageView1)
-        photoImageView2.addSubview(minusImageView2)
-        photoImageView3.addSubview(minusImageView3)
-        
         setupAutoLayout()
     }
     
-    private func configUI() {
-        updateImageViews(with: viewModel.photoSelectionModel.photoDatas)
-        updateMinusImageViews()
-    }
+//    private func configUI() {
+//        updateImageViews(with: viewModel.photoSelectionModel.photoDatas)
+//        updateMinusImageViews()
+//    }
     
-    private func resetImageViews() {
-        photoImageView1.image = UIImage(named: "PhotoIcon")
-        photoImageView2.image = UIImage(named: "PhotoIcon")
-        photoImageView3.image = UIImage(named: "PhotoIcon")
-        photoImageView1.contentMode = .center
-        photoImageView2.contentMode = .center
-        photoImageView3.contentMode = .center
-    }
+//    private func resetImageViews() {
+//        photoImageView1.image = UIImage(named: "PhotoIcon")
+//        photoImageView2.image = UIImage(named: "PhotoIcon")
+//        photoImageView3.image = UIImage(named: "PhotoIcon")
+//        photoImageView1.contentMode = .center
+//        photoImageView2.contentMode = .center
+//        photoImageView3.contentMode = .center
+//    }
     
-    private func updateImageViews(with photos: [Data]) {
-        for (index, data) in photos.enumerated() {
-            switch index {
-            case 0:
-                photoImageView1.image = UIImage(data: data)
-                photoImageView1.contentMode = .scaleAspectFill
-            case 1:
-                photoImageView2.image = UIImage(data: data)
-                photoImageView2.contentMode = .scaleAspectFill
-            case 2:
-                photoImageView3.image = UIImage(data: data)
-                photoImageView3.contentMode = .scaleAspectFill
-            default:
-                break
-            }
-        }
-    }
-    private func updateMinusImageViews() {
-        minusImageView1.isHidden = photoImageView1.image == UIImage(named: "PhotoIcon")
-        minusImageView2.isHidden = photoImageView2.image == UIImage(named: "PhotoIcon")
-        minusImageView3.isHidden = photoImageView3.image == UIImage(named: "PhotoIcon")
-    }
+//    private func updateImageViews(with photos: [Data]) {
+//        for (index, data) in photos.enumerated() {
+//            switch index {
+//            case 0:
+//                photoImageView1.image = UIImage(data: data)
+//                photoImageView1.contentMode = .scaleAspectFill
+//            case 1:
+//                photoImageView2.image = UIImage(data: data)
+//                photoImageView2.contentMode = .scaleAspectFill
+//            case 2:
+//                photoImageView3.image = UIImage(data: data)
+//                photoImageView3.contentMode = .scaleAspectFill
+//            default:
+//                break
+//            }
+//        }
+//    }
+    
+//    private func updateMinusImageViews() {
+//        minusImageView1.isHidden = photoImageView1.image == UIImage(named: "PhotoIcon")
+//        minusImageView2.isHidden = photoImageView2.image == UIImage(named: "PhotoIcon")
+//        minusImageView3.isHidden = photoImageView3.image == UIImage(named: "PhotoIcon")
+//    }
     
     private func buildLabel(text: String) -> UILabel {
         let label = UILabel()
@@ -256,69 +143,69 @@ final class PhotoSelectionViewController: UIViewController {
     
     // MARK: - Actions
     
-    @objc
-    func minusImageViewTapped(_ sender: UITapGestureRecognizer) {
-        let idx = sender.view?.tag == 1 ? 0 : sender.view?.tag == 2 ? 1 : 2
-        
-        viewModel.photoSelectionModel.photoDatas.remove(at: idx)
-        resetImageViews()
-        updateImageViews(with: viewModel.getPhotosArray())
-        updateMinusImageViews()
-    }
-    
-    @objc
-    func photoImageViewTapped() {
-        viewModel.authService.requestAuthorization { [weak self] result in
-            guard let self else { return }
-            
-            switch result {
-            case .success:
-                let vc = PhotoViewController(photosCount: viewModel.getPhotosCount(), photoSelectionLimitCount: 3)
-                vc.modalPresentationStyle = .fullScreen
-                vc.completionHandler = { photos in
-                    let photoDatas = photos.values.compactMap{ $0 }.compactMap{ $0.pngData() }
-                    self.viewModel.addPhotos(photos: photoDatas)
-                    
-                    for i in 0..<self.viewModel.getPhotosCount() {
-                        switch i {
-                        case 0:
-                            self.photoImageView1.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-                            self.photoImageView1.contentMode = .scaleAspectFill
-                            self.minusImageView1.isHidden = false
-                        case 1:
-                            self.photoImageView2.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-                            self.photoImageView2.contentMode = .scaleAspectFill
-                            self.minusImageView2.isHidden = false
-                        case 2:
-                            self.photoImageView3.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-                            self.photoImageView3.contentMode = .scaleAspectFill
-                            self.minusImageView3.isHidden = false
-                        default:
-                            continue
-                        }
-                    }
-                    
-                    switch self.viewModel.getPhotosCount() {
-                    case 1:
-                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
-                        self.photoImageView3.contentMode = .center
-                    case 0:
-                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
-                        self.photoImageView2.image = UIImage(named: "PhotoIcon")
-                        self.photoImageView3.contentMode = .center
-                        self.photoImageView2.contentMode = .center
-                    default:
-                        break
-                    }
-                }
-                
-                present(vc, animated: true)
-                
-            case .failure:
-                return
-            }
-        }
-    }
+//    @objc
+//    func minusImageViewTapped(_ sender: UITapGestureRecognizer) {
+//        let idx = sender.view?.tag == 1 ? 0 : sender.view?.tag == 2 ? 1 : 2
+//        
+//        viewModel.photoSelectionModel.photoDatas.remove(at: idx)
+//        resetImageViews()
+//        updateImageViews(with: viewModel.getPhotosArray())
+//        updateMinusImageViews()
+//    }
+//    
+//    @objc
+//    func photoImageViewTapped() {
+//        viewModel.authService.requestAuthorization { [weak self] result in
+//            guard let self else { return }
+//            
+//            switch result {
+//            case .success:
+//                let vc = PhotoViewController(photosCount: viewModel.getPhotosCount(), photoSelectionLimitCount: 3)
+//                vc.modalPresentationStyle = .fullScreen
+//                vc.completionHandler = { photos in
+//                    let photoDatas = photos.values.compactMap{ $0 }.compactMap{ $0.pngData() }
+//                    self.viewModel.addPhotos(photos: photoDatas)
+//                    
+//                    for i in 0..<self.viewModel.getPhotosCount() {
+//                        switch i {
+//                        case 0:
+//                            self.photoImageView1.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+//                            self.photoImageView1.contentMode = .scaleAspectFill
+//                            self.minusImageView1.isHidden = false
+//                        case 1:
+//                            self.photoImageView2.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+//                            self.photoImageView2.contentMode = .scaleAspectFill
+//                            self.minusImageView2.isHidden = false
+//                        case 2:
+//                            self.photoImageView3.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+//                            self.photoImageView3.contentMode = .scaleAspectFill
+//                            self.minusImageView3.isHidden = false
+//                        default:
+//                            continue
+//                        }
+//                    }
+//                    
+//                    switch self.viewModel.getPhotosCount() {
+//                    case 1:
+//                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
+//                        self.photoImageView3.contentMode = .center
+//                    case 0:
+//                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
+//                        self.photoImageView2.image = UIImage(named: "PhotoIcon")
+//                        self.photoImageView3.contentMode = .center
+//                        self.photoImageView2.contentMode = .center
+//                    default:
+//                        break
+//                    }
+//                }
+//                
+//                present(vc, animated: true)
+//                
+//            case .failure:
+//                return
+//            }
+//        }
+//    }
     
     @objc
     private func backButtonTapped() {
@@ -343,8 +230,8 @@ extension PhotoSelectionViewController {
         }
         
         requirementLabel.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom).offset(30)
-            $0.leading.equalToSuperview().offset(20)
+            $0.top.equalTo(headerView.snp.bottom).offset(Metric.requirementLabelTopOffset)
+            $0.leading.equalToSuperview().offset(Metric.sideMargin)
         }
         
         requirementTextView.snp.makeConstraints {
@@ -354,33 +241,14 @@ extension PhotoSelectionViewController {
         }
         
         photoLabel.snp.makeConstraints {
-            $0.top.equalTo(requirementTextView.snp.bottom).offset(40)
-            $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview().inset(280)
+            $0.top.equalTo(requirementTextView.snp.bottom).offset(Metric.photoLabelTopOffset)
+            $0.leading.equalToSuperview().offset(Metric.sideMargin)
         }
         
-        photoImageView1.snp.makeConstraints {
-            $0.width.equalTo(130.adjusted())
-            $0.height.equalTo(136.adjustedH())
-        }
-        
-        photoImageViewHStackView.snp.makeConstraints {
-            $0.edges.equalTo(photoImageHScrollView)
-            $0.height.equalTo(photoImageHScrollView)
-        }
-        
-        photoImageHScrollView.snp.makeConstraints {
-            $0.top.equalTo(photoLabel.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(20)
+        photoSelectionView.snp.makeConstraints {
+            $0.top.equalTo(photoLabel.snp.bottom).offset(Metric.requirementTextViewTopOffset)
+            $0.leading.equalToSuperview().offset(Metric.sideMargin)
             $0.trailing.equalToSuperview()
-        }
-        
-        [minusImageView1, minusImageView2, minusImageView3].forEach { imageView in
-            imageView.snp.makeConstraints {
-                $0.top.equalToSuperview().offset(5)
-                $0.trailing.equalToSuperview().offset(-5)
-                $0.size.equalTo(16)
-            }
         }
         
         bottomView.snp.makeConstraints {

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -107,6 +107,20 @@ final class PhotoSelectionViewController: UIViewController {
     }
     
     private func bind() {
+        let input = PhotoSelectionViewModel.Input(
+            textInput: requirementTextView.textInputPublisher,
+            addImageButtonTapped: photoSelectionView.addImageButtonTappedPublisher,
+            minusButtonTapped: photoSelectionView.minusButtonTappedPublisher,
+            nextButtonTapped: bottomView.nextButtonTappedPublisher
+        )
+        let output = viewModel.transform(input: input)
+        
+        output.updatePhotosData
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] photosData in
+                self?.photoSelectionView.upadtePhotoImageView(photosData: photosData)
+            }
+            .store(in: &cancellables)
         
     }
     
@@ -130,39 +144,6 @@ final class PhotoSelectionViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-//    private func resetImageViews() {
-//        photoImageView1.image = UIImage(named: "PhotoIcon")
-//        photoImageView2.image = UIImage(named: "PhotoIcon")
-//        photoImageView3.image = UIImage(named: "PhotoIcon")
-//        photoImageView1.contentMode = .center
-//        photoImageView2.contentMode = .center
-//        photoImageView3.contentMode = .center
-//    }
-    
-//    private func updateImageViews(with photos: [Data]) {
-//        for (index, data) in photos.enumerated() {
-//            switch index {
-//            case 0:
-//                photoImageView1.image = UIImage(data: data)
-//                photoImageView1.contentMode = .scaleAspectFill
-//            case 1:
-//                photoImageView2.image = UIImage(data: data)
-//                photoImageView2.contentMode = .scaleAspectFill
-//            case 2:
-//                photoImageView3.image = UIImage(data: data)
-//                photoImageView3.contentMode = .scaleAspectFill
-//            default:
-//                break
-//            }
-//        }
-//    }
-    
-//    private func updateMinusImageViews() {
-//        minusImageView1.isHidden = photoImageView1.image == UIImage(named: "PhotoIcon")
-//        minusImageView2.isHidden = photoImageView2.image == UIImage(named: "PhotoIcon")
-//        minusImageView3.isHidden = photoImageView3.image == UIImage(named: "PhotoIcon")
-//    }
-    
     private func buildLabel(text: String) -> UILabel {
         let label = UILabel()
         label.text = text
@@ -171,78 +152,60 @@ final class PhotoSelectionViewController: UIViewController {
         return label
     }
     
-    // MARK: - Actions
-    
-//    @objc
-//    func minusImageViewTapped(_ sender: UITapGestureRecognizer) {
-//        let idx = sender.view?.tag == 1 ? 0 : sender.view?.tag == 2 ? 1 : 2
-//        
-//        viewModel.photoSelectionModel.photoDatas.remove(at: idx)
-//        resetImageViews()
-//        updateImageViews(with: viewModel.getPhotosArray())
-//        updateMinusImageViews()
-//    }
-//    
-//    @objc
-//    func photoImageViewTapped() {
-//        viewModel.photoAuthService.requestAuthorization { [weak self] result in
-//            guard let self else { return }
-//            
-//            switch result {
-//            case .success:
-//                let vc = PhotoViewController(photosCount: viewModel.getPhotosCount(), photoSelectionLimitCount: 3)
-//                vc.modalPresentationStyle = .fullScreen
-//                vc.completionHandler = { photos in
-//                    let photoDatas = photos.values.compactMap{ $0 }.compactMap{ $0.pngData() }
-//                    self.viewModel.addPhotos(photos: photoDatas)
-//                    
-//                    for i in 0..<self.viewModel.getPhotosCount() {
-//                        switch i {
-//                        case 0:
-//                            self.photoImageView1.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-//                            self.photoImageView1.contentMode = .scaleAspectFill
-//                            self.minusImageView1.isHidden = false
-//                        case 1:
-//                            self.photoImageView2.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-//                            self.photoImageView2.contentMode = .scaleAspectFill
-//                            self.minusImageView2.isHidden = false
-//                        case 2:
-//                            self.photoImageView3.image = UIImage(data: self.viewModel.getPhoto(idx: i))
-//                            self.photoImageView3.contentMode = .scaleAspectFill
-//                            self.minusImageView3.isHidden = false
-//                        default:
-//                            continue
-//                        }
-//                    }
-//                    
-//                    switch self.viewModel.getPhotosCount() {
-//                    case 1:
-//                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
-//                        self.photoImageView3.contentMode = .center
-//                    case 0:
-//                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
-//                        self.photoImageView2.image = UIImage(named: "PhotoIcon")
-//                        self.photoImageView3.contentMode = .center
-//                        self.photoImageView2.contentMode = .center
-//                    default:
-//                        break
-//                    }
-//                }
-//                
-//                present(vc, animated: true)
-//                
-//            case .failure:
-//                return
-//            }
-//        }
-//    }
-//    
-//    @objc
-//    private func nextButtonTapped() {
-//        let model = viewModel.getPhotoSelectionModel()
-//        viewModel.dataManager.setRequirement(BouquetData.Requirement(text: model.text, images: model.photoDatas))
-//        coordinator?.showCustomizingSummaryVC()
-//    }
+    //
+    //    @objc
+    //    func photoImageViewTapped() {
+    //        viewModel.photoAuthService.requestAuthorization { [weak self] result in
+    //            guard let self else { return }
+    //
+    //            switch result {
+    //            case .success:
+    //                let vc = PhotoViewController(photosCount: viewModel.getPhotosCount(), photoSelectionLimitCount: 3)
+    //                vc.modalPresentationStyle = .fullScreen
+    //                vc.completionHandler = { photos in
+    //                    let photoDatas = photos.values.compactMap{ $0 }.compactMap{ $0.pngData() }
+    //                    self.viewModel.addPhotos(photos: photoDatas)
+    //
+    //                    for i in 0..<self.viewModel.getPhotosCount() {
+    //                        switch i {
+    //                        case 0:
+    //                            self.photoImageView1.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+    //                            self.photoImageView1.contentMode = .scaleAspectFill
+    //                            self.minusImageView1.isHidden = false
+    //                        case 1:
+    //                            self.photoImageView2.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+    //                            self.photoImageView2.contentMode = .scaleAspectFill
+    //                            self.minusImageView2.isHidden = false
+    //                        case 2:
+    //                            self.photoImageView3.image = UIImage(data: self.viewModel.getPhoto(idx: i))
+    //                            self.photoImageView3.contentMode = .scaleAspectFill
+    //                            self.minusImageView3.isHidden = false
+    //                        default:
+    //                            continue
+    //                        }
+    //                    }
+    //
+    //                    switch self.viewModel.getPhotosCount() {
+    //                    case 1:
+    //                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
+    //                        self.photoImageView3.contentMode = .center
+    //                    case 0:
+    //                        self.photoImageView3.image = UIImage(named: "PhotoIcon")
+    //                        self.photoImageView2.image = UIImage(named: "PhotoIcon")
+    //                        self.photoImageView3.contentMode = .center
+    //                        self.photoImageView2.contentMode = .center
+    //                    default:
+    //                        break
+    //                    }
+    //                }
+    //
+    //                present(vc, animated: true)
+    //
+    //            case .failure:
+    //                return
+    //            }
+    //        }
+    //    }
 }
 
 // MARK: - AutoLayout

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -141,6 +141,12 @@ final class PhotoSelectionViewController: UIViewController {
                 }
             }
             .store(in: &cancellables)
+        
+        output.showCustomizingSummaryView
+            .sink { [weak self] _ in
+                self?.coordinator?.showCustomizingSummaryVC()
+            }
+            .store(in: &cancellables)
     }
     
     private func observe() {
@@ -153,12 +159,6 @@ final class PhotoSelectionViewController: UIViewController {
         bottomView.backButtonTappedPublisher
             .sink { [weak self] _ in
                 self?.navigationController?.popViewController(animated: true)
-            }
-            .store(in: &cancellables)
-        
-        bottomView.nextButtonTappedPublisher
-            .sink { [weak self] _ in
-                self?.coordinator?.showCustomizingSummaryVC()
             }
             .store(in: &cancellables)
     }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 import SnapKit
 import Photos
 
@@ -32,6 +33,7 @@ final class PhotoSelectionViewController: UIViewController {
     // MARK: - Properties
     
     private let viewModel: PhotoSelectionViewModel
+    private var cancellables = Set<AnyCancellable>()
     weak var coordinator: CustomizingCoordinator?
     
     // MARK: - UI
@@ -95,6 +97,18 @@ final class PhotoSelectionViewController: UIViewController {
         setupAutoLayout()
     }
     
+    private func bind() {
+        
+    }
+    
+    private func observe() {
+        bottomView.backButtonTappedPublisher
+            .sink { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+    }
+    
 //    private func configUI() {
 //        updateImageViews(with: viewModel.photoSelectionModel.photoDatas)
 //        updateMinusImageViews()
@@ -155,7 +169,7 @@ final class PhotoSelectionViewController: UIViewController {
 //    
 //    @objc
 //    func photoImageViewTapped() {
-//        viewModel.authService.requestAuthorization { [weak self] result in
+//        viewModel.photoAuthService.requestAuthorization { [weak self] result in
 //            guard let self else { return }
 //            
 //            switch result {

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -122,6 +122,12 @@ final class PhotoSelectionViewController: UIViewController {
                 self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellables)
+        
+        bottomView.nextButtonTappedPublisher
+            .sink { [weak self] _ in
+                self?.coordinator?.showCustomizingSummaryVC()
+            }
+            .store(in: &cancellables)
     }
     
 //    private func resetImageViews() {
@@ -230,13 +236,13 @@ final class PhotoSelectionViewController: UIViewController {
 //            }
 //        }
 //    }
-    
-    @objc
-    private func nextButtonTapped() {
-        let model = viewModel.getPhotoSelectionModel()
-        viewModel.dataManager.setRequirement(BouquetData.Requirement(text: model.text, images: model.photoDatas))
-        coordinator?.showCustomizingSummaryVC()
-    }
+//    
+//    @objc
+//    private func nextButtonTapped() {
+//        let model = viewModel.getPhotoSelectionModel()
+//        viewModel.dataManager.setRequirement(BouquetData.Requirement(text: model.text, images: model.photoDatas))
+//        coordinator?.showCustomizingSummaryVC()
+//    }
 }
 
 // MARK: - AutoLayout

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -22,6 +22,8 @@ final class PhotoSelectionViewController: UIViewController {
     /// Attributes
     private enum Attributes {
         static let headerViewTitle = "추가로 사장님께\n요구할 사항들을 작성해주세요"
+        static let requirementLabelText = "요구사항"
+        static let photoLabelText = "참고 사진"
     }
     
     // MARK: - Properties
@@ -38,23 +40,9 @@ final class PhotoSelectionViewController: UIViewController {
         title: Attributes.headerViewTitle
     )
     
-    private let requirementLabel: UILabel = {
-        let label = UILabel()
-        label.text = "요구사항"
-        label.textColor = .black
-        label.font = .Pretendard(size: 16, family: .SemiBold)
-        return label
-    }()
-    
+    private lazy var requirementLabel = buildLabel(text: Attributes.requirementLabelText)
     private let requirementTextView = RequirementTextView()
-    
-    private let photoLabel: UILabel = {
-        let label = UILabel()
-        label.text = "참고 사진"
-        label.textColor = .black
-        label.font = .Pretendard(size: 16, family: .SemiBold)
-        return label
-    }()
+    private lazy var photoLabel = buildLabel(text: Attributes.photoLabelText)
     
     private lazy var addImageButton: UIImageView = {
         let imageView = UIImageView()
@@ -256,6 +244,14 @@ final class PhotoSelectionViewController: UIViewController {
         minusImageView1.isHidden = photoImageView1.image == UIImage(named: "PhotoIcon")
         minusImageView2.isHidden = photoImageView2.image == UIImage(named: "PhotoIcon")
         minusImageView3.isHidden = photoImageView3.image == UIImage(named: "PhotoIcon")
+    }
+    
+    private func buildLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.textColor = .black
+        label.font = .Pretendard(size: 16, family: .SemiBold)
+        return label
     }
     
     // MARK: - Actions

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewController.swift
@@ -10,6 +10,18 @@ import Photos
 
 final class PhotoSelectionViewController: UIViewController {
     
+    // MARK: - Enums
+    
+    /// Metrics
+    private enum Metric {
+        static let sideMargin = 20.0
+    }
+    
+    /// Attributes
+    private enum Attributes {
+        static let headerViewTitle = "추가로 사장님께\n요구할 사항들을 작성해주세요"
+    }
+    
     // MARK: - Properties
     
     private let viewModel: PhotoSelectionViewModel
@@ -17,9 +29,12 @@ final class PhotoSelectionViewController: UIViewController {
     
     // MARK: - UI
     
-    private lazy var exitButton = ExitButton(currentVC: self, coordinator: coordinator)
-    private let progressHStackView = CustomProgressHStackView(numerator: 6, denominator: 7)
-    private let titleLabel = CustomTitleLabel(text: "추가로 사장님께\n요구할 사항들을 작성해주세요")
+    private lazy var headerView = CustomHeaderView(
+        currentVC: self,
+        coordinator: coordinator,
+        numerator: 6,
+        title: Attributes.headerViewTitle
+    )
     
     private let requirementLabel: UILabel = {
         let label = UILabel()
@@ -216,16 +231,12 @@ final class PhotoSelectionViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        extendedLayoutIncludesOpaqueBars = true
-        navigationController?.setNavigationBarHidden(true, animated: false)
-        tabBarController?.tabBar.isHidden = true
+        configNavigationBar(isHidden: true)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        extendedLayoutIncludesOpaqueBars = false
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        tabBarController?.tabBar.isHidden = false
+        configNavigationBar(isHidden: false)
     }
     
     // MARK: - Functions
@@ -233,9 +244,9 @@ final class PhotoSelectionViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .white
         
-        view.addSubview(exitButton)
-        view.addSubview(progressHStackView)
-        view.addSubview(titleLabel)
+        [
+            headerView
+        ].forEach(view.addSubview(_:))
         
         view.addSubview(requirementLabel)
         view.addSubview(requirementTextView)
@@ -375,25 +386,13 @@ final class PhotoSelectionViewController: UIViewController {
 
 extension PhotoSelectionViewController {
     private func setupAutoLayout() {
-        exitButton.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(17)
-            $0.leading.equalToSuperview().offset(22)
-        }
-        
-        progressHStackView.snp.makeConstraints {
-            $0.top.equalTo(exitButton.snp.bottom).offset(29)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(19.5)
-            $0.height.equalTo(12.75)
-        }
-        
-        titleLabel.snp.makeConstraints {
-            $0.top.equalTo(progressHStackView.snp.bottom).offset(32)
-            $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview().inset(20)
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview().inset(Metric.sideMargin)
         }
         
         requirementLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(30)
+            $0.top.equalTo(headerView.snp.bottom).offset(30)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().inset(280)
         }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
@@ -13,6 +13,7 @@ final class PhotoSelectionViewModel: ViewModel {
     // MARK: - Properties
     
     struct Input {
+        let textInput: AnyPublisher<String, Never>
         let nextButtonTapped: AnyPublisher<Void, Never>
     }
     
@@ -23,7 +24,9 @@ final class PhotoSelectionViewModel: ViewModel {
     let dataManager: BouquetDataManaging
     let photoAuthService: PhotoAuthService
     var photoSelectionModel: PhotoSelectionModel
+    private let textInputSubject = CurrentValueSubject<String, Never>("")
     private let showCustomizingSummaryViewSubject = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Initialize
     
@@ -40,6 +43,11 @@ final class PhotoSelectionViewModel: ViewModel {
     // MARK: - Functions
     
     func transform(input: Input) -> Output {
+        
+        input.textInput
+            .assign(to: \.value, on: textInputSubject)
+            .store(in: &cancellables)
+        
         return Output(
             showCustomizingSummaryView: showCustomizingSummaryViewSubject.eraseToAnyPublisher()
         )

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
@@ -12,12 +12,16 @@ final class PhotoSelectionViewModel {
     // MARK: - Properties
     
     let dataManager: BouquetDataManaging
-    let authService = MyPhotoAuthService()
+    let photoAuthService: PhotoAuthService
     var photoSelectionModel: PhotoSelectionModel
     
     // MARK: - Initialize
     
-    init(dataManager: BouquetDataManaging = BouquetDataManager.shared) {
+    init(
+        dataManager: BouquetDataManaging = BouquetDataManager.shared,
+        authService: PhotoAuthService = MyPhotoAuthService()
+    ) {
+        self.photoAuthService = authService
         self.dataManager = dataManager
         let requirement = dataManager.getRequirement()
         photoSelectionModel = PhotoSelectionModel(photoDatas: requirement.images, text: requirement.text)

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
@@ -16,18 +16,21 @@ final class PhotoSelectionViewModel: ViewModel {
         let textInput: AnyPublisher<String, Never>
         let addImageButtonTapped: AnyPublisher<Void, Never>
         let minusButtonTapped: AnyPublisher<Int, Never>
+        let photosSelected: AnyPublisher<[Data], Never>
         let nextButtonTapped: AnyPublisher<Void, Never>
     }
     
     struct Output {
         let updatePhotosData: AnyPublisher<[Data], Never>
+        let showPhotoView: AnyPublisher<Int, Never>
         let showCustomizingSummaryView: AnyPublisher<Void, Never>
     }
     
     private let dataManager: BouquetDataManaging
     private let photoAuthService: PhotoAuthService
-    private let requirementPhotos = CurrentValueSubject<[Data], Never>([])
     private let textInputSubject = CurrentValueSubject<String, Never>("")
+    private let requirementPhotos = CurrentValueSubject<[Data], Never>([])
+    private let showPhotoViewSubject = PassthroughSubject<Int, Never>()
     private let showCustomizingSummaryViewSubject = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
     
@@ -48,16 +51,36 @@ final class PhotoSelectionViewModel: ViewModel {
             .assign(to: \.value, on: textInputSubject)
             .store(in: &cancellables)
         
+        input.addImageButtonTapped
+            .sink { [weak self] _ in
+                self?.requestPhotoAuthorization()
+            }
+            .store(in: &cancellables)
+        
         input.minusButtonTapped
             .sink { [weak self] index in
                 self?.removePhoto(at: index)
             }
             .store(in: &cancellables)
         
+        input.photosSelected
+            .sink { [weak self] photoDatas in
+                self?.addPhotos(photoDatas)
+            }
+            .store(in: &cancellables)
+        
         return Output(
             updatePhotosData: requirementPhotos.eraseToAnyPublisher(),
+            showPhotoView: showPhotoViewSubject.eraseToAnyPublisher(),
             showCustomizingSummaryView: showCustomizingSummaryViewSubject.eraseToAnyPublisher()
         )
+    }
+    
+    private func addPhotos(_ photos: [Data]) {
+        var currentPhotos = requirementPhotos.value
+        let remainingCapacity = max(0, 3 - currentPhotos.count)
+        currentPhotos.append(contentsOf: photos.prefix(remainingCapacity))
+        requirementPhotos.send(currentPhotos)
     }
     
     private func removePhoto(at index: Int) {
@@ -66,5 +89,17 @@ final class PhotoSelectionViewModel: ViewModel {
         guard index >= 0 && index < currentPhotos.count else { return }
         currentPhotos.remove(at: index)
         requirementPhotos.send(currentPhotos)
+    }
+    
+    private func requestPhotoAuthorization() {
+        photoAuthService.requestAuthorization { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                self.showPhotoViewSubject.send(requirementPhotos.value.count)
+            case .failure:
+                break
+            }
+        }
     }
 }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
@@ -6,14 +6,24 @@
 //
 
 import Foundation
+import Combine
 
-final class PhotoSelectionViewModel {
+final class PhotoSelectionViewModel: ViewModel {
     
     // MARK: - Properties
+    
+    struct Input {
+        let nextButtonTapped: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let showCustomizingSummaryView: AnyPublisher<Void, Never>
+    }
     
     let dataManager: BouquetDataManaging
     let photoAuthService: PhotoAuthService
     var photoSelectionModel: PhotoSelectionModel
+    private let showCustomizingSummaryViewSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Initialize
     
@@ -28,6 +38,12 @@ final class PhotoSelectionViewModel {
     }
     
     // MARK: - Functions
+    
+    func transform(input: Input) -> Output {
+        return Output(
+            showCustomizingSummaryView: showCustomizingSummaryViewSubject.eraseToAnyPublisher()
+        )
+    }
     
     func getPhotoSelectionModel() -> PhotoSelectionModel {
         return photoSelectionModel

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/PhotoSelectionViewModel.swift
@@ -69,6 +69,18 @@ final class PhotoSelectionViewModel: ViewModel {
             }
             .store(in: &cancellables)
         
+        input.nextButtonTapped
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                let requirement = BouquetData.Requirement(
+                    text: textInputSubject.value,
+                    images: requirementPhotos.value
+                )
+                self.dataManager.setRequirement(requirement)
+                self.showCustomizingSummaryViewSubject.send()
+            }
+            .store(in: &cancellables)
+        
         return Output(
             updatePhotosData: requirementPhotos.eraseToAnyPublisher(),
             showPhotoView: showPhotoViewSubject.eraseToAnyPublisher(),

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
@@ -186,6 +186,30 @@ final class PhotoSelectionView: UIView {
         return imageView
     }
     
+    func upadtePhotoImageView(photosData: [Data]) {
+        let photoImageViews = [
+            photoImageView1,
+            photoImageView2,
+            photoImageView3
+        ]
+        let minusImageViews = [
+            minusImageView1,
+            minusImageView2,
+            minusImageView3
+        ]
+        
+        for (index, photoData) in photosData.enumerated() {
+            photoImageViews[index].image = UIImage(data: photoData)
+            photoImageViews[index].contentMode = .scaleAspectFill
+            minusImageViews[index].isHidden = false
+        }
+        
+        for index in photosData.count..<photoImageViews.count {
+            photoImageViews[index].image = Attributes.photoIcon
+            photoImageViews[index].contentMode = .center
+            minusImageViews[index].isHidden = true
+        }
+    }
     // MARK: - Actions
     
     @objc

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class PhotoSelectionView: UIView {
     
@@ -28,6 +29,18 @@ final class PhotoSelectionView: UIView {
     
     // MARK: - Properties
     
+    private let addImageButtonTappedSubject = PassthroughSubject<Void, Never>()
+    private let minusButtonTappedSubject = PassthroughSubject<Int, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var addImageButtonTappedPublisher: AnyPublisher<Void, Never> {
+        return addImageButtonTappedSubject.eraseToAnyPublisher()
+    }
+    
+    var minusButtonTappedPublisher: AnyPublisher<Int, Never> {
+        return minusButtonTappedSubject.eraseToAnyPublisher()
+    }
+    
     // MARK: - UI
     
     private let scrollView: UIScrollView = {
@@ -44,7 +57,9 @@ final class PhotoSelectionView: UIView {
             backgroundColor: .gray02,
             tintColor: .black
         )
-        // 터치 이벤트 필요
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(addImageButtonTapped))
+        imageView.isUserInteractionEnabled = true
+        imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
     
@@ -63,7 +78,10 @@ final class PhotoSelectionView: UIView {
             cornerRadius: 0,
             isHidden: true
         )
-        // 터치 이벤트 필요
+        imageView.tag = 0
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
+        imageView.isUserInteractionEnabled = true
+        imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
     
@@ -82,7 +100,10 @@ final class PhotoSelectionView: UIView {
             cornerRadius: 0,
             isHidden: true
         )
-        // 터치 이벤트 필요
+        imageView.tag = 1
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
+        imageView.isUserInteractionEnabled = true
+        imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
     
@@ -101,7 +122,10 @@ final class PhotoSelectionView: UIView {
             cornerRadius: 0,
             isHidden: true
         )
-        // 터치 이벤트 필요
+        imageView.tag = 2
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
+        imageView.isUserInteractionEnabled = true
+        imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
     
@@ -160,6 +184,19 @@ final class PhotoSelectionView: UIView {
         imageView.layer.masksToBounds = cornerRadius > 0
         imageView.isHidden = isHidden
         return imageView
+    }
+    
+    // MARK: - Actions
+    
+    @objc
+    private func addImageButtonTapped() {
+        addImageButtonTappedSubject.send()
+    }
+    
+    @objc
+    private func minusButtonTapped(_ sender: UITapGestureRecognizer) {
+        guard let index = sender.view?.tag else { return }
+        minusButtonTappedSubject.send(index)
     }
 }
 

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
@@ -58,7 +58,6 @@ final class PhotoSelectionView: UIView {
             tintColor: .black
         )
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(addImageButtonTapped))
-        imageView.isUserInteractionEnabled = true
         imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
@@ -80,7 +79,6 @@ final class PhotoSelectionView: UIView {
         )
         imageView.tag = 0
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
-        imageView.isUserInteractionEnabled = true
         imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
@@ -102,7 +100,6 @@ final class PhotoSelectionView: UIView {
         )
         imageView.tag = 1
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
-        imageView.isUserInteractionEnabled = true
         imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
@@ -124,7 +121,6 @@ final class PhotoSelectionView: UIView {
         )
         imageView.tag = 2
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(minusButtonTapped(_:)))
-        imageView.isUserInteractionEnabled = true
         imageView.addGestureRecognizer(tapGesture)
         return imageView
     }()
@@ -182,6 +178,7 @@ final class PhotoSelectionView: UIView {
         imageView.contentMode = contentMode
         imageView.layer.cornerRadius = cornerRadius
         imageView.layer.masksToBounds = cornerRadius > 0
+        imageView.isUserInteractionEnabled = true
         imageView.isHidden = isHidden
         return imageView
     }

--- a/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
+++ b/WHOA_iOS/UI/FlowerCustomizing/PhotoSelection/Views/PhotoSelectionView.swift
@@ -1,0 +1,191 @@
+//
+//  PhotoSelectionView.swift
+//  WHOA_iOS
+//
+//  Created by KSH on 11/22/24.
+//
+
+import UIKit
+
+final class PhotoSelectionView: UIView {
+    
+    // MARK: - Enums
+    
+    /// Metrics
+    private enum Metric {
+        static let imageViewWidth = UIScreen.main.bounds.width > 375 ? 150.0 : 130.0
+        static let imageViewHeightMultiplier = 1.04
+        static let minusButtonInset = 5.0
+        static let minusButtonSize = 16.0
+    }
+    
+    /// Attributes
+    private enum Attributes {
+        static let plusImage = UIImage(systemName: "plus.circle")
+        static let photoIcon = UIImage(named: "PhotoIcon")
+        static let minusButton = UIImage(named: "MinusButton")
+    }
+    
+    // MARK: - Properties
+    
+    // MARK: - UI
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.alwaysBounceVertical = false
+        return scrollView
+    }()
+    
+    private lazy var addImageButton: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.plusImage,
+            backgroundColor: .gray02,
+            tintColor: .black
+        )
+        // 터치 이벤트 필요
+        return imageView
+    }()
+    
+    private lazy var photoImageView1: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.photoIcon,
+            backgroundColor: .gray02
+        )
+        return imageView
+    }()
+    
+    private lazy var minusImageView1: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.minusButton,
+            contentMode: .scaleAspectFill,
+            cornerRadius: 0,
+            isHidden: true
+        )
+        // 터치 이벤트 필요
+        return imageView
+    }()
+    
+    private lazy var photoImageView2: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.photoIcon,
+            backgroundColor: .gray02
+        )
+        return imageView
+    }()
+    
+    private lazy var minusImageView2: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.minusButton,
+            contentMode: .scaleAspectFill,
+            cornerRadius: 0,
+            isHidden: true
+        )
+        // 터치 이벤트 필요
+        return imageView
+    }()
+    
+    private lazy var photoImageView3: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.photoIcon,
+            backgroundColor: .gray02
+        )
+        return imageView
+    }()
+    
+    private lazy var minusImageView3: UIImageView = {
+        let imageView = buildImageView(
+            image: Attributes.minusButton,
+            contentMode: .scaleAspectFill,
+            cornerRadius: 0,
+            isHidden: true
+        )
+        // 터치 이벤트 필요
+        return imageView
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            addImageButton,
+            photoImageView1,
+            photoImageView2,
+            photoImageView3
+        ])
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 12
+        return stackView
+    }()
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        backgroundColor = .white
+        
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        photoImageView1.addSubview(minusImageView1)
+        photoImageView2.addSubview(minusImageView2)
+        photoImageView3.addSubview(minusImageView3)
+        
+        setupAutoLayout()
+    }
+    
+    private func buildImageView(
+        image: UIImage?,
+        backgroundColor: UIColor? = .clear,
+        tintColor: UIColor? = nil,
+        contentMode: UIView.ContentMode = .center,
+        cornerRadius: CGFloat = 10,
+        isHidden: Bool = false
+    ) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.image = image
+        imageView.tintColor = tintColor
+        imageView.backgroundColor = backgroundColor
+        imageView.contentMode = contentMode
+        imageView.layer.cornerRadius = cornerRadius
+        imageView.layer.masksToBounds = cornerRadius > 0
+        imageView.isHidden = isHidden
+        return imageView
+    }
+}
+
+// MARK: - AutoLayout
+
+extension PhotoSelectionView {
+    private func setupAutoLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.height.equalToSuperview()
+        }
+        
+        photoImageView1.snp.makeConstraints {
+            $0.width.equalTo(Metric.imageViewWidth)
+            $0.height.equalTo(photoImageView1.snp.width).multipliedBy(Metric.imageViewHeightMultiplier)
+        }
+        
+        [minusImageView1, minusImageView2, minusImageView3].forEach { imageView in
+            imageView.snp.makeConstraints {
+                $0.top.trailing.equalToSuperview().inset(Metric.minusButtonInset)
+                $0.size.equalTo(Metric.minusButtonSize)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Task
1. ViewModel Input/Output 패턴 적용: 데이터 흐름을 명확화를 하고 코드의 일관성을 유지하기 위해 ViewModel에 Input/Output 패턴을 적용했습니다.
2. Metric 및 Attributes Enum 도입: UI 요소에 관련된 상수들을 Metric 및 Attributes라는 Enum으로 분리하여 상수 값들을 한 곳에서 관리하고 유지보수성을 높였습니다.

 ## Issue 번호
* resolved: #76
* resolved: #21 

# 변경 사항 및 이유

> [구매목적 뷰 리팩토링](https://gist.github.com/Hun-322/bd438a325a86629ee77637d0947464c5)을 참고해주시면 됩니다.